### PR TITLE
Potential fix for code scanning alert no. 8: Clear-text logging of sensitive information

### DIFF
--- a/tools/get_apple_id.ts
+++ b/tools/get_apple_id.ts
@@ -84,8 +84,13 @@ async function scrapeAppleId() {
 
         if (accounts.length > 0) {
             console.log('成功解析到账号信息:');
+            // 为保护敏感数据，不再在控制台打印完整账号信息
+            const regionStats: { [region: string]: number } = {};
             accounts.forEach(acc => {
-                console.log(`地区: ${acc.region}, 账号: ${acc.email}, 密码: ${acc.password}`);
+                regionStats[acc.region] = (regionStats[acc.region] || 0) + 1;
+            });
+            Object.entries(regionStats).forEach(([region, count]) => {
+                console.log(`地区: ${region}, 发现账号数: ${count}`);
             });
             
             updateMarkdownFile(accounts);


### PR DESCRIPTION
Potential fix for [https://github.com/ermaozi/ermao.net/security/code-scanning/8](https://github.com/ermaozi/ermao.net/security/code-scanning/8)

To eliminate the clear-text logging of sensitive information, especially passwords and account emails, only non-sensitive metadata should be logged. Specifically, in line 88, instead of logging the full account credentials, log only a summary (e.g., how many accounts were found, or region names). Remove any output of the actual password and Apple ID (email) from log messages. Change `console.log(\`地区: ... 密码: ...\`);` to something like `console.log(\`地区: ... 的账号已找到, 共 ... 个\`);`, or omit the per-account log output entirely. No new imports or libraries are needed, just removal of sensitive data from log statements.

- Edit `tools/get_apple_id.ts`.
- Specifically edit the block where accounts are printed (line 88 and possibly related lines).
- Do **not** log emails or passwords.  
- You may keep a summary statement such as "X accounts parsed in total" or "Found accounts for region Y".

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
