### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-clash.yml
+++ b/.github/workflows/update-clash.yml
@@ -1,4 +1,6 @@
 name: Update Clash Assets
+permissions:
+  contents: read
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/ermaozi/ermao.net/security/code-scanning/9](https://github.com/ermaozi/ermao.net/security/code-scanning/9)

To resolve the issue:
- Add an explicit `permissions` block specifying minimal required permissions (`contents: read`) to the workflow. This should be added at the top level, under the workflow name or directly before the `jobs:` key so it applies to all jobs in the workflow.  
- No further imports or code changes are necessary, as all edits are contained within the YAML workflow definition.  
- This fix ensures the workflow will not inherit potentially excessive GitHub token permissions and instead restricts them to read-only for repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
